### PR TITLE
feat: add CloudFormation template for KEPOD infrastructure setup

### DIFF
--- a/cloudformation/kepod-stack.yaml
+++ b/cloudformation/kepod-stack.yaml
@@ -1,0 +1,110 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  RoleArn:
+    Type: String
+    Default: "arn:aws:iam::868610198161:role/LabRole"
+Resources:
+  # VPC
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "10.0.0.0/16"
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: kepod-vpc
+  # Subnets
+  Subnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.0.1.0/24"
+      AvailabilityZone: "us-east-1a"
+      Tags:
+        - Key: Name
+          Value: kepod-subnet-1
+  Subnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.0.2.0/24"
+      AvailabilityZone: "us-east-1b"
+      Tags:
+        - Key: Name
+          Value: kepod-subnet-2
+  # Internet Gateway
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+  GatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  # Route Table
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+  Route:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref InternetGateway
+  SubnetRouteTableAssociation1:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet1
+      RouteTableId: !Ref RouteTable
+  SubnetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet2
+      RouteTableId: !Ref RouteTable
+  # Security Group for EKS and Fargate
+  EKSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref VPC
+      GroupDescription: "Security group for KEPOD EKS cluster"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3000
+          ToPort: 3000
+          CidrIp: "0.0.0.0/0" # Open to all
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          CidrIp: "0.0.0.0/0" # WebSocket
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "10.0.0.0/16" # EKS control plane to pods
+      SecurityGroupEgress:
+        - IpProtocol: -1 # All outbound
+          FromPort: 0
+          ToPort: 65535
+          CidrIp: "0.0.0.0/0"
+      Tags:
+        - Key: Name
+          Value: kepod-eks-sg
+  # EKS Cluster
+  EKSCluster:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: kepod-cluster
+      RoleArn: !Ref RoleArn
+      ResourcesVpcConfig:
+        SubnetIds:
+          - !Ref Subnet1
+          - !Ref Subnet2
+        SecurityGroupIds:
+          - !Ref EKSSecurityGroup
+Outputs:
+  ClusterName:
+    Value: !Ref EKSCluster
+  VpcId:
+    Value: !Ref VPC
+  SecurityGroupId:
+    Value: !Ref EKSSecurityGroup


### PR DESCRIPTION
This pull request includes significant changes to the `cloudformation/kepod-stack.yaml` file to set up a new AWS infrastructure using CloudFormation. The most important changes include defining a VPC, creating subnets, setting up an internet gateway, configuring a route table, and establishing an EKS cluster with the necessary security groups.

Infrastructure setup:

* Defined a VPC with CIDR block `10.0.0.0/16`, DNS support, and DNS hostnames enabled.
* Created two subnets within the VPC, each in different availability zones (`us-east-1a` and `us-east-1b`).
* Set up an internet gateway and attached it to the VPC.
* Configured a route table with a route to the internet gateway and associated it with the subnets.

EKS cluster configuration:

* Created a security group for the EKS cluster with specific ingress and egress rules.
* Established an EKS cluster with the defined subnets and security group, and provided an output for the cluster name, VPC ID, and security group ID.