### PR TITLE
feat: add provisioner deployment and SQS listener; integrate AWS SDK for environment provisioning

### DIFF
--- a/Dockerfile.provisioner
+++ b/Dockerfile.provisioner
@@ -1,0 +1,13 @@
+FROM --platform=linux/amd64 node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+CMD ["node", "dist/provisioner/queueListener.js"]

--- a/k8s/kepod-cluster-role-binding.yaml
+++ b/k8s/kepod-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kepod-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kepod
+roleRef:
+  kind: ClusterRole
+  name: kepod-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/kepod-cluster-role.yaml
+++ b/k8s/kepod-cluster-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kepod-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "get", "list", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "get", "list", "update", "delete"]

--- a/k8s/provisioner-deployment.yaml
+++ b/k8s/provisioner-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kepod-provisioner
+  namespace: kepod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kepod-provisioner
+  template:
+    metadata:
+      labels:
+        app: kepod-provisioner
+    spec:
+      containers:
+        - name: kepod-provisioner
+          image: 868610198161.dkr.ecr.us-east-1.amazonaws.com/kepod-provisioner:latest
+          env:
+            - name: AWS_REGION
+              value: "us-east-1"
+            - name: DYNAMODB_TABLE
+              value: "kepod-environments"
+            - name: SQS_QUEUE_URL
+              value: "https://sqs.us-east-1.amazonaws.com/868610198161/kepod-provisioning-queue"
+            - name: AWS_ACCESS_KEY_ID
+              value: "<your-access-key-id>"
+            - name: AWS_SECRET_ACCESS_KEY
+              value: "<your-secret-access-key>"
+            - name: AWS_SESSION_TOKEN
+              value: "<your-session-token>"
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"

--- a/src/awsClients.ts
+++ b/src/awsClients.ts
@@ -1,0 +1,19 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { SQSClient } from '@aws-sdk/client-sqs';
+import { fromEnv } from '@aws-sdk/credential-providers';
+import { AWS_REGION } from './utils/constants.js';
+import 'dotenv/config';
+
+// Create DynamoDB Client
+const dynamoClient = new DynamoDBClient({
+  region: AWS_REGION,
+  credentials: fromEnv(),
+});
+
+// Create SQS Client
+const sqsClient = new SQSClient({
+  region: AWS_REGION,
+  credentials: fromEnv(),
+});
+
+export { dynamoClient, sqsClient };

--- a/src/provisioner/provisioner.ts
+++ b/src/provisioner/provisioner.ts
@@ -1,0 +1,102 @@
+import { UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import { KubeConfig, CoreV1Api, AppsV1Api, V1Namespace, V1Deployment, V1Service } from '@kubernetes/client-node';
+import { DYNAMODB_TABLE, SQS_QUEUE_URL, STATUS } from '../utils/constants.js';
+import { SQSMessageBody } from '../types/sqsMessageBodyTypes.js';
+import { DeleteMessageCommand } from '@aws-sdk/client-sqs';
+import { dynamoClient, sqsClient } from '../awsClients.js';
+
+const kc = new KubeConfig();
+kc.loadFromDefault();
+const k8sCoreApi = kc.makeApiClient(CoreV1Api);
+const k8sAppsApi = kc.makeApiClient(AppsV1Api);
+
+export async function provisionEnvironment({ env_id, env_name, image, ttl, namespace, targetPort }: SQSMessageBody, message: any) {
+  try {
+    await createNamespace(k8sCoreApi, namespace);
+    await createDeployment(k8sAppsApi, namespace, env_name, image);
+    const appUrl = await createService(k8sCoreApi, namespace, env_name, targetPort);
+
+    const dynamoParams = {
+      TableName: DYNAMODB_TABLE,
+      Key: { env_id: { S: env_id } },
+      UpdateExpression: 'SET #status = :status, #url = :url',
+      ExpressionAttributeNames: { '#status': 'status', '#url': 'app_url' },
+      ExpressionAttributeValues: {
+        ':status': { S: STATUS.READY },
+        ':url': { S: appUrl },
+      },
+    };
+
+    await dynamoClient.send(new UpdateItemCommand(dynamoParams));
+
+    await sqsClient.send(new DeleteMessageCommand({
+      QueueUrl: SQS_QUEUE_URL,
+      ReceiptHandle: message.ReceiptHandle,
+    }));
+
+    console.log(`Environment ${env_id} provisioned with URL: ${appUrl}`);
+  } catch (error) {
+    console.error(`Failed to provision env_id ${env_id}:`, error);
+    throw error;
+  }
+}
+
+async function createNamespace(k8sCoreApi: CoreV1Api, namespace: string) {
+  const namespaceSpec: V1Namespace = {
+    metadata: { name: namespace },
+  };
+
+  try {
+    await k8sCoreApi.createNamespace({ body: namespaceSpec });
+    
+    console.log(`Created namespace: ${namespace}`);
+  } catch (err: any) {
+    if (err.response?.statusCode !== 409) throw err;
+    console.log(`Namespace ${namespace} already exists`);
+  }
+}
+
+async function createDeployment(k8sAppsApi: AppsV1Api, namespace: string, env_name: string, image: string) {
+  const deploymentSpec: V1Deployment = {
+    metadata: { name: `${namespace}-app`, namespace },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: env_name } },
+      template: {
+        metadata: { labels: { app: env_name } },
+        spec: { containers: [{ name: env_name, image, resources: { requests: { cpu: '100m', memory: '128Mi' } } }] },
+      },
+    },
+  };
+
+  try {
+    await k8sAppsApi.createNamespacedDeployment({ namespace, body: deploymentSpec });
+    console.log(`Created deployment: ${namespace}-app`);
+  } catch (err: any) {
+    if (err.response?.statusCode !== 409) throw err;
+    console.log(`Deployment ${namespace}-app already exists`);
+  }
+}
+
+async function createService(k8sCoreApi: CoreV1Api, namespace: string, env_name: string, targetPort: number) {
+  const serviceSpec: V1Service = {
+    metadata: { name: `${namespace}-svc`, namespace },
+    spec: {
+      selector: { app: env_name },
+      ports: [{ port: 80, targetPort }],
+      type: 'LoadBalancer',
+    },
+  };
+
+  try {
+    const service = await k8sCoreApi.createNamespacedService({ namespace, body: serviceSpec });
+    const ingress = service.status?.loadBalancer?.ingress?.[0];
+    const hostname = ingress?.hostname || 'pending';
+    console.log(`Created service: ${namespace}-svc`);
+    return hostname;
+  } catch (err: any) {
+    if (err.response?.statusCode !== 409) throw err;
+    console.log(`Service ${namespace}-svc already exists`);
+    return 'existing-service';
+  }
+}

--- a/src/provisioner/queueListener.ts
+++ b/src/provisioner/queueListener.ts
@@ -1,0 +1,25 @@
+import { Consumer } from 'sqs-consumer';
+import { provisionEnvironment } from './provisioner.js';
+import { SQS_QUEUE_URL } from '../utils/constants.js';
+import { sqsClient } from '../awsClients.js';
+
+const app = Consumer.create({
+  queueUrl: SQS_QUEUE_URL,
+  sqs: sqsClient,
+  handleMessage: async (message) => {
+    const body = JSON.parse(message.Body || '{}');
+    console.log(`Received message for env_id: ${body.env_id}`);
+    await provisionEnvironment(body, message);
+  },
+});
+
+app.on('error', (err) => {
+  console.error('Queue listener error:', err);
+});
+
+app.on('processing_error', (err) => {
+  console.error('Message processing error:', err);
+});
+
+console.log('Starting SQS listener...');
+app.start();

--- a/src/types/sqsMessageBodyTypes.ts
+++ b/src/types/sqsMessageBodyTypes.ts
@@ -1,0 +1,8 @@
+export interface SQSMessageBody {
+  env_id: string
+  env_name: string
+  image: string
+  ttl: number
+  namespace: string
+  targetPort: number
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,4 +7,4 @@ export const STATUS = {
 
 export const AWS_REGION = process.env.AWS_REGION || 'us-east-1';
 export const DYNAMODB_TABLE = process.env.DYNAMODB_TABLE || 'kepod-environments';
-export const SQS_QUEUE_URL = process.env.SQS_QUEUE_URL || '';
+export const SQS_QUEUE_URL = process.env.SQS_QUEUE_URL || 'https://sqs.us-east-1.amazonaws.com/868610198161/kepod-provisioning-queue';


### PR DESCRIPTION
This pull request introduces significant changes to implement a Kubernetes-based environment provisioning system. The changes include the addition of Docker, Kubernetes configurations, AWS client setup, and the core provisioning logic.

Key changes include:

**Docker and Kubernetes Configuration:**
* Added a `Dockerfile.provisioner` to set up a Node.js environment for the provisioner service.
* Created Kubernetes configuration files for role-based access control, deployment, and service setup:
  * `kepod-cluster-role.yaml` defines permissions for managing namespaces, deployments, and services.
  * `kepod-cluster-role-binding.yaml` binds the defined role to a service account.
  * `provisioner-deployment.yaml` sets up the deployment of the provisioner service with necessary environment variables and resource limits.

**AWS Client Setup:**
* Added `awsClients.ts` to create and export DynamoDB and SQS clients using environment-based credentials.

**Provisioning Logic:**
* Implemented the core provisioning logic in `provisioner.ts`, which includes functions to create Kubernetes namespaces, deployments, and services, and update DynamoDB with the provisioning status.
* Added a queue listener in `queueListener.ts` to process SQS messages and trigger the provisioning logic.

**Utility and Types:**
* Defined the `SQSMessageBody` interface in `sqsMessageBodyTypes.ts` for type safety.
* Updated `constants.ts` to include the SQS queue URL.