### PR TITLE
refactor: remove unused winston-transport dependency and custom WebSocket transport from logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "sqs-consumer": "^11.6.0",
         "uuid": "^11.1.0",
         "winston": "^3.17.0",
-        "winston-transport": "^4.9.0",
         "ws": "^8.18.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "sqs-consumer": "^11.6.0",
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
-    "winston-transport": "^4.9.0",
     "ws": "^8.18.1"
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,18 +1,5 @@
 import { createLogger, format, transports } from 'winston';
-import Transport from 'winston-transport';
 import { config } from '../config/config.js';
-import { broadcastLog } from '../websocket.js';
-
-// Custom WebSocket Transport
-class WebSocketTransport extends Transport {
-  constructor() {
-    super();
-  }
-  log(info: any, callback: () => void) {
-    broadcastLog({ message: info.message, env_name: info.env_name || 'unknown', timestamp: info.timestamp });
-    callback();
-  }
-}
 
 const logger = createLogger({
   level: config.env === 'development' ? 'debug' : 'info',
@@ -22,7 +9,6 @@ const logger = createLogger({
   ),
   transports: [
     new transports.Console(),
-    new WebSocketTransport(),
   ],
 });
 


### PR DESCRIPTION
This pull request includes changes to the logging system by removing a custom WebSocket transport and simplifying the `logger` setup. Additionally, an unnecessary dependency has been removed from the `package.json` file.

Changes to logging system:

* [`src/utils/logger.ts`](diffhunk://#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544L2-L15): Removed the custom `WebSocketTransport` class and its usage in the `logger` setup. [[1]](diffhunk://#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544L2-L15) [[2]](diffhunk://#diff-0b242f99cdb5b36e8a0aa886862c30c2f480aca7512bcfc3e2fa4889055d4544L25)

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L33): Removed the `winston-transport` dependency.